### PR TITLE
Add Team-based FixVersion report

### DIFF
--- a/check_codebase.sh
+++ b/check_codebase.sh
@@ -9,22 +9,22 @@ echo "flake8..."
 echo "-----------------------------" >> argus_health.txt
 echo "Running flake8" >> argus_health.txt
 echo "-----------------------------" >> argus_health.txt
-python3.6 -m flake8 --ignore E501,E702,F401,F811,F812,F822,F823,F831,F841,N8,C9 argus.py >> argus_health.txt 2>&1
-python3.6 -m flake8 --ignore E501,E702,F401,F811,F812,F822,F823,F831,F841,N8,C9 src/* >> argus_health.txt 2>&1
+python3 -m flake8 --ignore E501,E702,F401,F811,F812,F822,F823,F831,F841,N8,C9 argus.py >> argus_health.txt 2>&1
+python3 -m flake8 --ignore E501,E702,F401,F811,F812,F822,F823,F831,F841,N8,C9 src/* >> argus_health.txt 2>&1
 
 echo 'pycodestyle...'
 echo "-----------------------------" >> argus_health.txt
 echo "Running pycodestyle" >> argus_health.txt
 echo "-----------------------------" >> argus_health.txt
-python3.6 -m pycodestyle --ignore=E501 argus.py >> argus_health.txt 2>&1
-python3.6 -m pycodestyle --ignore=E501 src/ >> argus_health.txt 2>&1
+python3 -m pycodestyle --ignore=E501 argus.py >> argus_health.txt 2>&1
+python3 -m pycodestyle --ignore=E501 src/ >> argus_health.txt 2>&1
 
 echo 'pylint...'
 echo "-----------------------------" >> argus_health.txt
 echo "Running pylint" >> argus_health.txt
 echo "-----------------------------" >> argus_health.txt
-python3.6 -m pylint --disable=all --enable=E,F argus.py >> argus_health.txt 2>&1
-python3.6 -m pylint --disable=all --enable=E,F src/ >> argus_health.txt 2>&1
+python3 -m pylint --disable=all --enable=E,F argus.py >> argus_health.txt 2>&1
+python3 -m pylint --disable=all --enable=E,F src/ >> argus_health.txt 2>&1
 
 echo 'results written to argus_health.txt. Opening with less.'
 less argus_health.txt

--- a/check_codebase.sh
+++ b/check_codebase.sh
@@ -1,30 +1,42 @@
 #!/bin/bash
 
+if [ $1 = "-?" ]; then
+	echo "usage: check_codebase.sh <pyver>"
+	echo "   pyver: optional python command to run (instead of python)"
+	exit
+fi
+
+pycmd="python"
+
+if [ $1 ]; then
+	pycmd=$1
+fi
+
 echo "Checking health of argus code-base. Please wait..."
 
 cur_date=`date`
 echo "Health check: $cur_date" > argus_health.txt
 
-echo "flake8..."
+echo "$pycmd -m flake8..."
 echo "-----------------------------" >> argus_health.txt
-echo "Running flake8" >> argus_health.txt
+echo "Running flake8 with pycmd: $pycmd" >> argus_health.txt
 echo "-----------------------------" >> argus_health.txt
-python3 -m flake8 --ignore E501,E702,F401,F811,F812,F822,F823,F831,F841,N8,C9 argus.py >> argus_health.txt 2>&1
-python3 -m flake8 --ignore E501,E702,F401,F811,F812,F822,F823,F831,F841,N8,C9 src/* >> argus_health.txt 2>&1
+$pycmd -m flake8 --ignore E501,E702,F401,F811,F812,F822,F823,F831,F841,N8,C9 argus.py >> argus_health.txt 2>&1
+$pycmd -m flake8 --ignore E501,E702,F401,F811,F812,F822,F823,F831,F841,N8,C9 src/* >> argus_health.txt 2>&1
 
-echo 'pycodestyle...'
+echo "$pycmd -m pycodestyle..."
 echo "-----------------------------" >> argus_health.txt
-echo "Running pycodestyle" >> argus_health.txt
+echo "Running pycodestyle with pycmd: $pycmd" >> argus_health.txt
 echo "-----------------------------" >> argus_health.txt
-python3 -m pycodestyle --ignore=E501 argus.py >> argus_health.txt 2>&1
-python3 -m pycodestyle --ignore=E501 src/ >> argus_health.txt 2>&1
+$pycmd -m pycodestyle --ignore=E501 argus.py >> argus_health.txt 2>&1
+$pycmd -m pycodestyle --ignore=E501 src/ >> argus_health.txt 2>&1
 
-echo 'pylint...'
+echo "$pycmd -m pylint..."
 echo "-----------------------------" >> argus_health.txt
-echo "Running pylint" >> argus_health.txt
+echo "Running pylint with pycmd: $pycmd" >> argus_health.txt
 echo "-----------------------------" >> argus_health.txt
-python3 -m pylint --disable=all --enable=E,F argus.py >> argus_health.txt 2>&1
-python3 -m pylint --disable=all --enable=E,F src/ >> argus_health.txt 2>&1
+$pycmd -m pylint --disable=all --enable=E,F argus.py >> argus_health.txt 2>&1
+$pycmd -m pylint --disable=all --enable=E,F src/ >> argus_health.txt 2>&1
 
 echo 'results written to argus_health.txt. Opening with less.'
 less argus_health.txt

--- a/src/member_issues_by_status.py
+++ b/src/member_issues_by_status.py
@@ -72,10 +72,10 @@ class MemberIssuesByStatus:
         self._aliased_names = {}
 
         # WARNING: These containers also need to be reflected in self.clear and self.sort_tickets
-        self.assigned = []
-        self.closed = []
-        self.reviewer = []
-        self.reviewed = []
+        self.assigned = []  # type: List[JiraIssue]
+        self.closed = []  # type: List[JiraIssue]
+        self.reviewer = []  # type: List[JiraIssue]
+        self.reviewed = []  # type: List[JiraIssue]
 
     def clone_empty(self):
         """
@@ -236,6 +236,10 @@ class MemberIssuesByStatus:
         self.closed = []
         self.reviewer = []
         self.reviewed = []
+
+    @property
+    def all_tickets(self) -> List[JiraIssue]:
+        return self.assigned + self.closed + self.reviewer + self.reviewed
 
     def display_member_issues(self, jira_manager: JiraManager, report_filter: 'ReportFilter') -> List[JiraIssue]:
         """

--- a/src/member_issues_by_status.py
+++ b/src/member_issues_by_status.py
@@ -13,20 +13,19 @@
 # limitations under the License.
 
 import itertools
-from typing import TYPE_CHECKING
-
+from typing import TYPE_CHECKING, List, Optional
 
 from src.display_filter import DisplayFilter
+from src.jira_issue import JiraIssue
+from src.jira_manager import JiraManager
 from src.jira_utils import JiraUtils
-from src.utils import argus_debug, pick_value
+from src.utils import pick_value
 
 if TYPE_CHECKING:
     from configparser import RawConfigParser
     from src.jira_connection import JiraConnection
-    from src.jira_manager import JiraManager
     from src.jira_issue import JiraIssue
     from src.team_reports import ReportFilter
-    from typing import List, Optional
 
 
 class JiraUserName:
@@ -238,8 +237,7 @@ class MemberIssuesByStatus:
         self.reviewer = []
         self.reviewed = []
 
-    def display_member_issues(self, jira_manager, report_filter):
-        # type: (JiraManager, ReportFilter) -> List[JiraIssue]
+    def display_member_issues(self, jira_manager: JiraManager, report_filter: 'ReportFilter') -> List[JiraIssue]:
         """
         Prints details for tickets by category. This method is always executed in the context of having a relevant
         ReportFilter in use for the display. Can use a no-op all-inclusive ReportFilter if you want to report all issues

--- a/src/member_issues_by_status.py
+++ b/src/member_issues_by_status.py
@@ -13,19 +13,15 @@
 # limitations under the License.
 
 import itertools
-from typing import TYPE_CHECKING, List, Optional
+from configparser import RawConfigParser
+from typing import List, Optional
 
 from src.display_filter import DisplayFilter
+from src.jira_connection import JiraConnection
 from src.jira_issue import JiraIssue
 from src.jira_manager import JiraManager
 from src.jira_utils import JiraUtils
 from src.utils import pick_value
-
-if TYPE_CHECKING:
-    from configparser import RawConfigParser
-    from src.jira_connection import JiraConnection
-    from src.jira_issue import JiraIssue
-    from src.team_reports import ReportFilter
 
 
 class JiraUserName:
@@ -36,8 +32,7 @@ class JiraUserName:
     is uniquely identified by a: the name, b: the jira connection, and c: the team.
     """
 
-    def __init__(self, user_name, jira_connection_name, team_name):
-        # type: (str, str, str) -> None
+    def __init__(self, user_name: str, jira_connection_name: str, team_name: str) -> None:
         self.user_name = user_name
         self.jira_connection_name = jira_connection_name
         self.team_name = team_name
@@ -47,8 +42,7 @@ class JiraUserName:
         return '{}:{}:{}'.format(self.user_name, self.jira_connection_name, self.team_name)
 
     @classmethod
-    def from_combined_string(cls, combined_string):
-        # type: (str) -> JiraUserName
+    def from_combined_string(cls, combined_string: str) -> 'JiraUserName':
         sa = combined_string.split(':')
         if len(sa) != 3:
             raise Exception('Got bad string to JiraUserName.from_combined_string. Expected : delim with 3 members, got: {}'.format(combined_string))
@@ -72,10 +66,11 @@ class MemberIssuesByStatus:
         self._aliased_names = {}
 
         # WARNING: These containers also need to be reflected in self.clear and self.sort_tickets
-        self.assigned = []  # type: List[JiraIssue]
-        self.closed = []  # type: List[JiraIssue]
-        self.reviewer = []  # type: List[JiraIssue]
-        self.reviewed = []  # type: List[JiraIssue]
+        self.assigned = List[JiraIssue]
+        self.assigned = List[JiraIssue]
+        self.closed = List[JiraIssue]
+        self.reviewer = List[JiraIssue]
+        self.reviewed = List[JiraIssue]
 
     def clone_empty(self):
         """
@@ -86,8 +81,7 @@ class MemberIssuesByStatus:
             result.add_alias(alias)
         return result
 
-    def save_config(self, config_parser):
-        # type: (RawConfigParser) -> None
+    def save_config(self, config_parser: RawConfigParser) -> None:
         config_parser.add_section(self.full_name)
 
         # Create comma delimited list of : delimited known names for this linked user
@@ -97,8 +91,7 @@ class MemberIssuesByStatus:
         # We do not serialize the issues we iterate over within this object
 
     @classmethod
-    def from_file(cls, root_name, config_parser):
-        # type: (str, RawConfigParser) -> MemberIssuesByStatus
+    def from_file(cls, root_name: str, config_parser: RawConfigParser) -> 'MemberIssuesByStatus':
         new_user = JiraUserName.from_combined_string(root_name)
         result = MemberIssuesByStatus(new_user)
 
@@ -109,16 +102,14 @@ class MemberIssuesByStatus:
         return result
 
     @property
-    def connection_names(self):
-        # type: () -> List[str]
+    def connection_names(self) -> List[str]:
         result = [self.primary_name.jira_connection_name]
         for combined_name in list(self._aliased_names.values()):
             result.append(combined_name.jira_connection_name)
         return result
 
     @property
-    def full_name(self):
-        # type: () -> str
+    def full_name(self) -> str:
         return self.primary_name.to_combined_string
 
     @property
@@ -126,16 +117,13 @@ class MemberIssuesByStatus:
         return self.primary_name.user_name
 
     @property
-    def primary_team(self):
-        # type: () -> str
+    def primary_team(self) -> str:
         return self.primary_name.team_name
 
-    def add_alias(self, jira_user_name):
-        # type: (JiraUserName) -> None
+    def add_alias(self, jira_user_name: JiraUserName) -> None:
         self._aliased_names[jira_user_name.to_combined_string] = jira_user_name
 
-    def remove_alias(self):
-        # type: () -> bool
+    def remove_alias(self) -> bool:
         if len(self._aliased_names) == 0:
             print('No aliases. Returning.')
             return False
@@ -185,21 +173,20 @@ class MemberIssuesByStatus:
         return True
 
     @staticmethod
-    def _debug_ticket(jira_issue, input):
+    def _debug_ticket(jira_issue, to_print: str):
         """
         Developer tool to debug matching / JiraIssue categorization logic for reports
         """
         if MemberIssuesByStatus.is_debug_jira_issue(jira_issue):
-            print('DEBUG: {}'.format(input))
+            print('DEBUG: {}'.format(to_print))
 
     @staticmethod
-    def is_debug_jira_issue(jira_issue):
+    def is_debug_jira_issue(jira_issue: JiraIssue):
         # Change XXX-1234 to the ticket you'd like to debug, add calls to _debug_ticket in relevant locations
         # return jira_issue.issue_key == 'XXX-1234'
         return False
 
-    def get_owning_jira_user_name(self, jira_connection, jira_issue):
-        # type: (JiraConnection, JiraIssue) -> Optional[JiraUserName]
+    def get_owning_jira_user_name(self, jira_connection: JiraConnection, jira_issue: JiraIssue) -> Optional[JiraUserName]:
         """
         Determines which, if any, of the JiraUserNames associated with this MemberIssuesByStatus worked on this JiraIssue
         """

--- a/src/member_issues_by_status.py
+++ b/src/member_issues_by_status.py
@@ -66,11 +66,11 @@ class MemberIssuesByStatus:
         self._aliased_names = {}
 
         # WARNING: These containers also need to be reflected in self.clear and self.sort_tickets
-        self.assigned = List[JiraIssue]
-        self.assigned = List[JiraIssue]
-        self.closed = List[JiraIssue]
-        self.reviewer = List[JiraIssue]
-        self.reviewed = List[JiraIssue]
+        self.assigned: List[JiraIssue] = []
+        self.assigned: List[JiraIssue] = []
+        self.closed: List[JiraIssue] = []
+        self.reviewer: List[JiraIssue] = []
+        self.reviewed: List[JiraIssue] = []
 
     def clone_empty(self):
         """

--- a/src/team_manager.py
+++ b/src/team_manager.py
@@ -25,7 +25,7 @@ from src.jira_manager import JiraManager
 from src.jira_utils import JiraUtils
 from src.member_issues_by_status import JiraUserName, MemberIssuesByStatus
 from src.team import Team
-from src.team_reports import (ReportCurrentLoad, ReportFilter, ReportMomentum,
+from src.team_reports import (ReportCurrentLoad, ReportFilter, ReportFixVersion, ReportMomentum,
                               ReportReviewLoad, ReportTestLoad, ReportType)
 from src.utils import (clear, conf_dir, get_input, is_yes, pause, pick_value,
                        print_separator, save_argus_config)
@@ -217,7 +217,8 @@ class TeamManager:
             ReportType.MOMENTUM: ReportMomentum(),
             ReportType.CURRENT_LOAD: ReportCurrentLoad(),
             ReportType.TEST_LOAD: ReportTestLoad(),
-            ReportType.REVIEW_LOAD: ReportReviewLoad()
+            ReportType.REVIEW_LOAD: ReportReviewLoad(),
+            ReportType.FIXVERSION: ReportFixVersion()
         }
 
         while True:
@@ -237,6 +238,7 @@ class TeamManager:
             print('{}: Team load report: assigned bugs, assigned tests, assigned features, assigned reviews, patch available reviews'.format(ReportType.CURRENT_LOAD))
             print('{}: Test load report: snapshot of currently assigned tests and closed tests in a custom time frame'.format(ReportType.TEST_LOAD))
             print('{}: Review load report: snapshot of currently assigned reviews, Patch Available reviews, and finished reviews in a custom time frame'.format(ReportType.REVIEW_LOAD))
+            print('{}: FixVersion report: show data for all tickets on a fixversion over time frame'.format(ReportType.FIXVERSION))
             print('q: Cancel')
             print('---------------------')
             choice = get_input(':')
@@ -285,11 +287,12 @@ class TeamManager:
             member.sort_tickets()
 
     @staticmethod
-    def _run_report(jira_manager, team, report_filter):
-        # type: (JiraManager, Team, ReportFilter) -> None
+    def _run_report(jira_manager: JiraManager, team: Team, report_filter: ReportFilter) -> None:
         # We prompt for a new 'since' on each iteration of the loop
         if report_filter.needs_duration:
             report_filter.since = time_utils.since_now(ReportFilter.get_since())
+
+        report_filter.prompt_for_data()
 
         try:
             sorted_member_issues = sorted(team.members, key=lambda s: s.primary_name.user_name)

--- a/src/team_reports.py
+++ b/src/team_reports.py
@@ -20,9 +20,7 @@ from dateutil import parser
 from src.jira_issue import JiraIssue
 from src.member_issues_by_status import MemberIssuesByStatus
 from src.utils import get_input
-
-if TYPE_CHECKING:
-    from typing import List
+from typing import List
 
 
 class ReportType:
@@ -87,16 +85,13 @@ class ReportFilter:
             result += '{:<20}'.format(column)
         return result
 
-    def process_issues(self, member_issues):
-        # type: (MemberIssuesByStatus) -> None
+    def process_issues(self, member_issues: 'MemberIssuesByStatus') -> None:
         raise NotImplementedError()
 
-    def matches(self, jira_issue):
-        # type (JiraIssue) -> bool
+    def matches(self, jira_issue: JiraIssue) -> bool:
         raise NotImplementedError()
 
-    def _add_matching_issues(self, column_name, jira_issues):
-        # type: (str, List[JiraIssue]) -> None
+    def _add_matching_issues(self, column_name: str, jira_issues: List[JiraIssue]) -> None:
         """
         Adds issues matching this report filters criteria to the specified column
         """
@@ -105,23 +100,20 @@ class ReportFilter:
         for jira_issue in matching_issues:
             self.known_issues.add(jira_issue.issue_key)
 
-    def issue_count(self, issue_type):
-        # type: (str) -> int
+    def issue_count(self, issue_type: str) -> int:
         return len(self.issues[issue_type])
 
-    def print_all_counts(self, name):
+    def print_all_counts(self, name: str) -> str:
         # type: (str) -> str
         result = '{:<30}'.format(name)
         for column in self.columns:
             result += '{:<20}'.format(len(self.issues[column]))
         return result
 
-    def get_issues(self, issue_type):
-        # type: (str) -> List[JiraIssue]
+    def get_issues(self, issue_type: str) -> List[JiraIssue]:
         return self.issues[issue_type]
 
-    def contains_issue(self, jira_issue):
-        # type: (JiraIssue) -> bool
+    def contains_issue(self, jira_issue: JiraIssue) -> bool:
         """
         Used after report population to determine if an issue should be displayed by a MemberIssuesByStatus
         """

--- a/src/team_reports.py
+++ b/src/team_reports.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import datetime
-from typing import TYPE_CHECKING
 
 from dateutil import parser
 

--- a/src/team_reports.py
+++ b/src/team_reports.py
@@ -237,8 +237,8 @@ class ReportFixVersion(ReportFilter):
 
     def __init__(self):
         ReportFilter.__init__(self)
-        self.columns = ['Assigned', 'Closed non-test', 'Reviewed', 'Closed Test']
-        self.issues = {'Assigned': [], 'Closed non-test': [], 'Reviewed': [], 'Closed Test': []}
+        self.columns = ['Assigned', 'Closed non-test', 'Reviewed', 'Closed Test', 'Total']
+        self.issues = {'Assigned': [], 'Closed non-test': [], 'Reviewed': [], 'Closed Test': [], 'Total': []}
         self._fix_version = None
 
     def process_issues(self, member_issues: MemberIssuesByStatus) -> None:
@@ -248,6 +248,7 @@ class ReportFixVersion(ReportFilter):
         self._add_matching_issues('Closed non-test', [x for x in member_issues.closed if not x.is_test])
         self._add_matching_issues('Closed Test', [x for x in member_issues.closed if x.is_test])
         self._add_matching_issues('Reviewed', member_issues.reviewed)
+        self._add_matching_issues('Total', member_issues.all_tickets)
 
     def set_fix_version(self, new_version: str) -> None:
         self._fix_version = new_version

--- a/src/utils.py
+++ b/src/utils.py
@@ -149,8 +149,7 @@ def indent(num, value):
     print(to_print + value)
 
 
-def get_input(prompt, lowered=True):
-    # type: (str, bool) -> str
+def get_input(prompt: str, lowered: bool=True) -> str:
     response = input('{} '.format(prompt)).strip()
     if lowered:
         response = response.lower()


### PR DESCRIPTION
This also tidies up the formatting for team reports by adding some flags to the
DisplayFilter scope, namely to suppress dependency resolution regardless of
global settings, and also allowing a report to select between the pager and a
local print.